### PR TITLE
chore: CI validates themes using the lazygit config schema

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -1,0 +1,39 @@
+name: json-yaml-validate
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  json-yaml-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # download the latest schema so that we can avoid manually updating the
+      # schema in the repository
+      - name: Download lazygit configuration schema
+        run: |-
+          mkdir schemas
+          wget -O schemas/lazygit-schema.json https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json
+
+      - name: Validate themes-mergable
+        id: validate-themes-mergable
+        uses: GrantBirki/json-yaml-validate@v2.6.0
+        with:
+          base_dir: themes-mergable
+          json_schema: schemas/lazygit-schema.json
+
+          # This validator action supports validating both yaml and json files.
+          # However, the yaml validator it uses is "limited", and the
+          # recommendation is to use the json validator instead.
+          yaml_as_json: "true"
+
+          # This value can be found at the top of the lazygit schema url above
+          # in the "$schema" property. The schemas supported by the validator
+          # are documented in
+          # https://github.com/marketplace/actions/json-yaml-validate#inputs-
+          json_schema_version: "draft-2020-12"

--- a/build.ts
+++ b/build.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env
-import {  variants } from "npm:@catppuccin/palette@0.1.5";
+import { variants } from "npm:@catppuccin/palette@0.1.5";
 import { stringify as stringifyYaml } from "https://deno.land/std@0.201.0/yaml/stringify.ts";
 
+import { type Version0_40_2 } from "./schemas.ts"
 
 const accents = [
   "rosewater",
@@ -26,7 +27,7 @@ let count = 0
 Object.entries(variants)
   .forEach(([name, palette]) => {
     for (const accent of accents) {
-      const theme = {
+      const theme: Version0_40_2 = {
         theme: {
           activeBorderColor: [palette[accent].hex, "bold"],
           inactiveBorderColor: [palette.subtext0.hex],

--- a/schemas.ts
+++ b/schemas.ts
@@ -1,0 +1,19 @@
+import { JTDDataType } from "npm:ajv@8.12.0/dist/jtd"
+
+import version0_40_2 from "https://raw.githubusercontent.com/jesseduffield/lazygit/1a035db4c817ac07cd59f0f2aa4e1efd1a9b75b6/schema/config.json" with { type: "json" }
+import latestBleedingEdge from "https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json" with { type: "json" }
+
+// When importing, typescript knows the full type for the json at compile time.
+//
+// JTDDataType converts the type of the schema to a typescript type that
+// contains the properties in the schema.
+type Version0_40_2Schema = JTDDataType<typeof version0_40_2>
+type LatestBleedingEdgeSchema = JTDDataType<typeof latestBleedingEdge>
+type KnownSchemaVersion = Version0_40_2Schema | LatestBleedingEdgeSchema
+
+type Theme<Schema extends KnownSchemaVersion> = {
+  theme: Partial<Schema["gui"]["theme"]>
+}
+
+export type Version0_40_2 = Theme<Version0_40_2Schema>
+export type LatestBleedingEdge = Theme<LatestBleedingEdgeSchema>


### PR DESCRIPTION
The latest version of the schema is used. This means the color schemes in this repository are implicitly meant to be used in the latest lazygit development version.

The schema version could also be locked to a recent release, but at this time there is no nice way of resolving the latest version in the validation logic (github action).

Example of the workflow runs:
https://github.com/sp3ctum/lazygit/actions/workflows/validate-yaml.yml

---

I also noticed the schema validation complains an extra property is used in many files. I'll look into why this might be - I suppose the lazygit schema might have changed after the colorschemes were created in this repository.