### PR TITLE
feat!: remove deprecated selectedRangeBgColor key

### DIFF
--- a/lazygit-mergeable.hbs
+++ b/lazygit-mergeable.hbs
@@ -15,8 +15,6 @@ gui:
       - '#{{ blue }}'
     selectedLineBgColor:
       - '#{{ surface0 }}'
-    selectedRangeBgColor:
-      - '#{{ surface0 }}'
     cherryPickedCommitBgColor:
       - '#{{ surface1 }}'
     cherryPickedCommitFgColor:

--- a/lazygit.hbs
+++ b/lazygit.hbs
@@ -11,8 +11,6 @@ theme:
     - '#{{ blue }}'
   selectedLineBgColor:
     - '#{{ surface0 }}'
-  selectedRangeBgColor:
-    - '#{{ surface0 }}'
   cherryPickedCommitBgColor:
     - '#{{ surface1 }}'
   cherryPickedCommitFgColor:


### PR DESCRIPTION
This removes the selectedRangeBgColor key, which was removed by upstream lazygit (https://github.com/jesseduffield/lazygit/commit/f3eb180f75496637719895902abf76af10b8425f).