### PR TITLE
ci(release): don't build and push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,26 +17,3 @@ jobs:
         id: release
         with:
           release-type: simple
-
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
-
-      - uses: extractions/setup-just@v2
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: |
-          curl -fsSL https://github.com/catppuccin/toolbox/releases/download/whiskers-v2.3.0/whiskers-x86_64-unknown-linux-gnu -o $RUNNER_TEMP/whiskers
-          chmod +x $RUNNER_TEMP/whiskers
-          echo $RUNNER_TEMP >> $GITHUB_PATH
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: just all
-        if: ${{ steps.release.outputs.release_created }}
-      
-      - uses: EndBug/add-and-commit@v9
-        if: ${{ steps.release.outputs.release_created }}
-        with:
-          message: "chore: release (${{ steps.release.outputs.tag_name }})"
-          default_author: github_actions
-          tag: '${{ steps.release.outputs.tag_name }} --force'
-          tag_push: '--force'


### PR DESCRIPTION
This PR removes all the logic in the `release.yml` to build and push up changes
on release. 

I don't believe this workflow is doing much since the themes are already in
source control and I would sincerely hope that they are updated before a release
PR is merged.

I'd suggest creating a "whiskers check" workflow to run on push/pull-request if
you want that confidence. (e.g. [catppuccin/fleet](https://github.com/catppuccin/fleet/blob/main/.github/workflows/whiskers-check.yml))
