### PR TITLE
ci: add whiskers check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,18 @@
+name: Whiskers Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: catppuccin/setup-whiskers@v1
+        with:
+          whiskers-version: 2.3.0
+      - run: |
+          whiskers lazygit.tera --check


### PR DESCRIPTION

The `--check` command is buggy for multi file outputs on v2.3.0 but I'll update
to the fixed version (v2.5.1) in a later PR (or via Renovate later)
