### PR TITLE
doc: remove deprecated `selectedRangeBgColor` key from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ add flags to lazygit which will merge it from our presets.
          - '#89b4fa'
        selectedLineBgColor:
          - '#313244'
-       selectedRangeBgColor:
-         - '#313244'
        cherryPickedCommitBgColor:
          - '#45475a'
        cherryPickedCommitFgColor:


### PR DESCRIPTION
Thanks for creating and maintaining such a nice lazygit themes!

This PR is a follow-up to #31.