### PR TITLE
ci(check): use reusable workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,18 +1,15 @@
-name: Whiskers Check
+name: whiskers
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: catppuccin/setup-whiskers@v1
-        with:
-          whiskers-version: 2.5.1
-      - run: |
-          whiskers lazygit.tera --check
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: lazygit.tera
+    secrets: inherit


### PR DESCRIPTION
We now have a reusable workflow for checking whiskers in CI, which is to be used across the organisation.